### PR TITLE
Fix memory leak

### DIFF
--- a/pkg/cpu/cpu.go
+++ b/pkg/cpu/cpu.go
@@ -51,10 +51,11 @@ func (c *CPU) Start(client statsd.Client) error {
 func (c *CPU) Report() {
 	var prevTotal, prevIdle uint64
 	prev := new(linux.Stat)
+	tick := time.Tick(c.Interval)
 
 	for {
 		select {
-		case <-time.Tick(c.Interval):
+		case <-tick:
 			log.Info("cpu: reporting")
 
 			stat, err := linux.ReadStat(c.Path)

--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -45,9 +45,10 @@ func (d *Disk) Start(client statsd.Client) error {
 
 // Report resources.
 func (d *Disk) Report() {
+	tick := time.Tick(d.Interval)
 	for {
 		select {
-		case <-time.Tick(d.Interval):
+		case <-tick:
 			log.Info("disk: reporting")
 			stat, err := linux.ReadDisk(d.Path)
 

--- a/pkg/memory/memory.go
+++ b/pkg/memory/memory.go
@@ -52,9 +52,10 @@ func (m *Memory) Start(client statsd.Client) error {
 
 // Report resource.
 func (m *Memory) Report() {
+	tick := time.Tick(m.Interval)
 	for {
 		select {
-		case <-time.Tick(m.Interval):
+		case <-tick:
 			log.Info("memory: reporting")
 
 			stat, err := linux.ReadMemInfo(m.Path)


### PR DESCRIPTION
This should fix the memory leak were seeing. The problem was that a new ticker was being created on each for-loop iteration and [since tickers are not cleaned up](http://golang.org/src/pkg/time/tick.go?s=654:705#L10), we leaked a new ticker for every tick haha. So rather than messing with `Stop()`, I just moved the ticker channel out of the loop.
