### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+FROM google/golang-runtime


### PR DESCRIPTION
With a dockerfile based on `google/golang-runtime`, running `statsd/system` is as simple as

```
$ cd system
$ docker build -t system .
$ docker run system
```

Passing parameters is also possible by default:

```
$ docker run system -v
0.2.0
```


For simplicity of use, you could as well add this repo as an automated build to Docker Hub (like I did for testing with my fork - https://registry.hub.docker.com/u/janpapenbrock/system):

```
$ docker run janpapenbrock/system -v
0.2.0
```